### PR TITLE
Using native histograms to keep track of request latencies

### DIFF
--- a/internal/adguard/client.go
+++ b/internal/adguard/client.go
@@ -13,8 +13,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/henrywhitaker3/adguard-exporter/internal/config"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/henrywhitaker3/adguard-exporter/internal/config"
 )
 
 type Client struct {
@@ -143,10 +144,11 @@ func (c *Client) getQueryTimes(l *queryLog) ([]QueryTime, error) {
 			log.Printf("ERROR - could not parse query elapsed time %v as float\n", q.Elapsed)
 			continue
 		}
+
 		out = append(out, QueryTime{
-			Elapsed:  time.Millisecond * time.Duration(ms),
-			Client:   q.Client,
-			Upstream: q.Upstream,
+			ElapsedSeconds: time.Duration(ms) * time.Millisecond / time.Second,
+			Client:         q.Client,
+			Upstream:       q.Upstream,
 		})
 	}
 	return out, nil

--- a/internal/adguard/types.go
+++ b/internal/adguard/types.go
@@ -85,9 +85,9 @@ type logEntry struct {
 }
 
 type QueryTime struct {
-	Elapsed  time.Duration
-	Client   string
-	Upstream string
+	ElapsedSeconds time.Duration
+	Client         string
+	Upstream       string
 }
 
 type queryLog struct {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -59,9 +59,12 @@ var (
 		Help:      "The average query processing time in seconds",
 	}, []string{"server"})
 	ProcessingTimeBucket = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:      "processing_time_milliseconds",
-		Namespace: "adguard",
-		Help:      "The processing time of queries",
+		Name:                           "processing_time_seconds",
+		Namespace:                      "adguard",
+		Help:                           "The processing time of queries",
+		Buckets:                        []float64{0.01, 0.015, 0.18, 0.02, 0.22, 0.24, 0.26, 0.28, 0.03, 0.06, 0.09, 0.1},
+		NativeHistogramMaxBucketNumber: 256,
+		NativeHistogramBucketFactor:    1.1,
 	}, []string{"server", "client", "upstream"})
 	TopQueriedDomains = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "top_queried_domains",

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -132,6 +132,6 @@ func collectQueryLogStats(ctx context.Context, client *adguard.Client) {
 	for _, t := range times {
 		metrics.ProcessingTimeBucket.
 			WithLabelValues(client.Url(), t.Client, t.Upstream).
-			Observe(float64(t.Elapsed / time.Millisecond))
+			Observe(float64(t.ElapsedSeconds.Seconds()))
 	}
 }


### PR DESCRIPTION
## Summary

Using native histograms to keep track of latency, since they give much more precision on quantile estimates.

Also a couple of changes:

* Using seconds as measurement, following [Prometheus best practices](https://prometheus.io/docs/practices/naming/#base-units)
* Changing buckets for the metric to use custom values instead of the default buckets from prometheus.
