### PR TITLE
Additional  queries_details metric & query_types label

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ If you want to strip the scheme and port out of the `server` label in the metric
 | adguard_top_upstreams_avg_response_time_seconds   | The average response time for each of the top upstream servers    |
 | adguard_dhcp_enabled                              | Whether dhcp is enabled                                           |
 | adguard_dhcp_leases                               | The dhcp leases                                                   |
+| adguard_queries_details                           | Number of queries with additional labels                          |

--- a/README.md
+++ b/README.md
@@ -84,4 +84,5 @@ If you want to strip the scheme and port out of the `server` label in the metric
 | adguard_top_upstreams_avg_response_time_seconds   | The average response time for each of the top upstream servers    |
 | adguard_dhcp_enabled                              | Whether dhcp is enabled                                           |
 | adguard_dhcp_leases                               | The dhcp leases                                                   |
-| adguard_queries_details                           | Number of queries with additional labels                          |
+| adguard_queries_details                           | Queries with times and additional labels                          |
+| adguard_queries_details_histogram                 | Histogram of queries with times and additional labels             |

--- a/internal/adguard/client.go
+++ b/internal/adguard/client.go
@@ -95,7 +95,7 @@ func (c *Client) GetDhcp(ctx context.Context) (*DhcpStatus, error) {
 	return out, nil
 }
 
-func (c *Client) GetQueryLog(ctx context.Context) (map[string]int, []QueryTime, error) {
+func (c *Client) GetQueryLog(ctx context.Context) (map[string]map[string]int, []QueryTime, error) {
 	log := &queryLog{}
 	err := c.do(ctx, http.MethodGet, "/control/querylog?limit=1000&response_status=all", log)
 	if err != nil {
@@ -113,18 +113,21 @@ func (c *Client) GetQueryLog(ctx context.Context) (map[string]int, []QueryTime, 
 	return types, times, nil
 }
 
-func (c *Client) getQueryTypes(log *queryLog) (map[string]int, error) {
-	out := map[string]int{}
+func (c *Client) getQueryTypes(log *queryLog) (map[string]map[string]int, error) {
+	out := map[string]map[string]int{}
 	for _, d := range log.Log {
 		if d.Answer != nil && len(d.Answer) > 0 {
+			if _, ok := out[d.Client]; !ok {
+				out[d.Client] = map[string]int{}
+			}
 			for i := range d.Answer {
 				switch v := d.Answer[i].Value.(type) {
 				case string:
-					out[d.Answer[i].Type]++
+					out[d.Client][d.Answer[i].Type]++
 				case map[string]any:
 					dns65 := &type65{}
 					mapstructure.Decode(v, dns65)
-					out["TYPE"+strconv.Itoa(dns65.Hdr.Rrtype)]++
+					out[d.Client]["TYPE"+strconv.Itoa(dns65.Hdr.Rrtype)]++
 				}
 			}
 		}

--- a/internal/adguard/client.go
+++ b/internal/adguard/client.go
@@ -95,22 +95,24 @@ func (c *Client) GetDhcp(ctx context.Context) (*DhcpStatus, error) {
 	return out, nil
 }
 
-func (c *Client) GetQueryLog(ctx context.Context) (map[string]map[string]int, []QueryTime, error) {
+// func (c *Client) GetQueryLog(ctx context.Context) (map[string]map[string]int, []QueryTime, QueryPerClient, error) {
+func (c *Client) GetQueryLog(ctx context.Context) (map[string]map[string]int, []QueryTime, []logEntry, error) {
 	log := &queryLog{}
 	err := c.do(ctx, http.MethodGet, "/control/querylog?limit=1000&response_status=all", log)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	types, err := c.getQueryTypes(log)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	times, err := c.getQueryTimes(log)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return types, times, nil
+
+	return types, times, log.Log, nil
 }
 
 func (c *Client) getQueryTypes(log *queryLog) (map[string]map[string]int, error) {

--- a/internal/adguard/types.go
+++ b/internal/adguard/types.go
@@ -71,17 +71,25 @@ type type65 struct {
 	RData string    `json:"Rdata"`
 }
 
+type ClientInfo struct {
+	Whois          map[string]any `json:"whois"`
+	Name           string         `json:"name"`
+	DisallowedRule string         `json:"disallowed_rule"`
+	Disallowed     Bool           `json:"disallowed"`
+}
+
 type logEntry struct {
-	Answer      []answer `json:"answer"`
-	DNSSec      Bool     `json:"answer_dnssec"`
-	Client      string   `json:"client"`
-	ClientProto string   `json:"client_proto"`
-	Elapsed     string   `json:"elapsedMs"`
-	Question    query    `json:"question"`
-	Reason      string   `json:"reason"`
-	Status      string   `json:"status"`
-	Time        string   `json:"time"`
-	Upstream    string   `json:"upstream"`
+	Answer      []answer   `json:"answer"`
+	DNSSec      Bool       `json:"answer_dnssec"`
+	Client      string     `json:"client"`
+	ClientProto string     `json:"client_proto"`
+	Elapsed     string     `json:"elapsedMs"`
+	Question    query      `json:"question"`
+	Reason      string     `json:"reason"`
+	Status      string     `json:"status"`
+	Time        string     `json:"time"`
+	Upstream    string     `json:"upstream"`
+	ClientInfo  ClientInfo `json:"client_info"`
 }
 
 type QueryTime struct {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -93,11 +93,17 @@ var (
 		Namespace: "adguard",
 		Help:      "The number of queries for a specific type",
 	}, []string{"server", "type", "client"})
-	TotalQueriesDetails = prometheus.NewCounterVec(prometheus.CounterOpts{
+	TotalQueriesDetails = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "queries_details",
 		Namespace: "adguard",
 		Help:      "Total queries by user",
-	}, []string{"server", "user", "reason", "status", "upstream"})
+	}, []string{"server", "user", "reason", "status", "upstream", "client_name"})
+	TotalQueriesDetailsHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:      "queries_details_histogram",
+		Namespace: "adguard",
+		Help:      "Total queries by user",
+		Buckets:   prometheus.LinearBuckets(0, 10, 10),
+	}, []string{"server", "user", "reason", "status", "upstream", "client_name"})
 
 	// DHCP
 	DhcpEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -174,6 +180,7 @@ func Init() {
 	prometheus.MustRegister(QueryTypes)
 	prometheus.MustRegister(ProcessingTimeBucket)
 	prometheus.MustRegister(TotalQueriesDetails)
+	prometheus.MustRegister(TotalQueriesDetailsHistogram)
 
 	// Status
 	prometheus.MustRegister(Running)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -93,6 +93,11 @@ var (
 		Namespace: "adguard",
 		Help:      "The number of queries for a specific type",
 	}, []string{"server", "type", "client"})
+	TotalQueriesUser = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:      "queries_details",
+		Namespace: "adguard",
+		Help:      "Total queries by user",
+	}, []string{"server", "user", "reason", "status", "upstream"})
 
 	// DHCP
 	DhcpEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -168,6 +173,7 @@ func Init() {
 	prometheus.MustRegister(TopUpstreamsAvgTimes)
 	prometheus.MustRegister(QueryTypes)
 	prometheus.MustRegister(ProcessingTimeBucket)
+	prometheus.MustRegister(TotalQueriesUser)
 
 	// Status
 	prometheus.MustRegister(Running)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -92,7 +92,7 @@ var (
 		Name:      "query_types",
 		Namespace: "adguard",
 		Help:      "The number of queries for a specific type",
-	}, []string{"server", "type"})
+	}, []string{"server", "type", "client"})
 
 	// DHCP
 	DhcpEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -48,7 +48,7 @@ var (
 		Namespace: "adguard",
 		Help:      "Total queries that have been replaced due to safebrowsing",
 	}, []string{"server"})
-	ReplcaedParental = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	ReplacedParental = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "replaced_parental",
 		Namespace: "adguard",
 		Help:      "Total queries that have been replaced due to parental",
@@ -159,7 +159,7 @@ func Init() {
 	prometheus.MustRegister(BlockedFiltered)
 	prometheus.MustRegister(ReplacedSafesearch)
 	prometheus.MustRegister(ReplacedSafebrowsing)
-	prometheus.MustRegister(ReplcaedParental)
+	prometheus.MustRegister(ReplacedParental)
 	prometheus.MustRegister(AvgProcessingTime)
 	prometheus.MustRegister(TopBlockedDomains)
 	prometheus.MustRegister(TopClients)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -93,7 +93,7 @@ var (
 		Namespace: "adguard",
 		Help:      "The number of queries for a specific type",
 	}, []string{"server", "type", "client"})
-	TotalQueriesUser = prometheus.NewCounterVec(prometheus.CounterOpts{
+	TotalQueriesDetails = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name:      "queries_details",
 		Namespace: "adguard",
 		Help:      "Total queries by user",
@@ -173,7 +173,7 @@ func Init() {
 	prometheus.MustRegister(TopUpstreamsAvgTimes)
 	prometheus.MustRegister(QueryTypes)
 	prometheus.MustRegister(ProcessingTimeBucket)
-	prometheus.MustRegister(TotalQueriesUser)
+	prometheus.MustRegister(TotalQueriesDetails)
 
 	// Status
 	prometheus.MustRegister(Running)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -119,7 +119,7 @@ func collectDhcp(ctx context.Context, client *adguard.Client) {
 }
 
 func collectQueryLogStats(ctx context.Context, client *adguard.Client) {
-	stats, times, err := client.GetQueryLog(ctx)
+	stats, times, queries, err := client.GetQueryLog(ctx)
 	if err != nil {
 		log.Printf("ERROR - could not get query type stats: %v\n", err)
 		metrics.ScrapeErrors.WithLabelValues(client.Url()).Inc()
@@ -130,6 +130,10 @@ func collectQueryLogStats(ctx context.Context, client *adguard.Client) {
 		for t, v := range v {
 			metrics.QueryTypes.WithLabelValues(client.Url(), t, c).Set(float64(v))
 		}
+	}
+
+	for _, l := range queries {
+		metrics.TotalQueriesUser.WithLabelValues(client.Url(), l.Client, l.Reason, l.Status, l.Upstream).Inc()
 	}
 
 	for _, t := range times {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -126,9 +126,12 @@ func collectQueryLogStats(ctx context.Context, client *adguard.Client) {
 		return
 	}
 
-	for t, v := range stats {
-		metrics.QueryTypes.WithLabelValues(client.Url(), t).Set(float64(v))
+	for c, v := range stats {
+		for t, v := range v {
+			metrics.QueryTypes.WithLabelValues(client.Url(), t, c).Set(float64(v))
+		}
 	}
+
 	for _, t := range times {
 		metrics.ProcessingTimeBucket.
 			WithLabelValues(client.Url(), t.Client, t.Upstream).

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -56,7 +56,7 @@ func collectStats(ctx context.Context, client *adguard.Client) {
 	metrics.BlockedFiltered.WithLabelValues(client.Url()).Set(float64(stats.BlockedFilteredQueries))
 	metrics.ReplacedSafesearch.WithLabelValues(client.Url()).Set(float64(stats.ReplacedSafesearchQueries))
 	metrics.ReplacedSafebrowsing.WithLabelValues(client.Url()).Set(float64(stats.ReplacedSafebrowsingQueries))
-	metrics.ReplcaedParental.WithLabelValues(client.Url()).Set(float64(stats.ReplacedParentalQueries))
+	metrics.ReplacedParental.WithLabelValues(client.Url()).Set(float64(stats.ReplacedParentalQueries))
 	metrics.AvgProcessingTime.WithLabelValues(client.Url()).Set(float64(stats.AvgProcessingTime))
 
 	for _, c := range stats.TopClients {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -133,7 +133,7 @@ func collectQueryLogStats(ctx context.Context, client *adguard.Client) {
 	}
 
 	for _, l := range queries {
-		metrics.TotalQueriesUser.WithLabelValues(client.Url(), l.Client, l.Reason, l.Status, l.Upstream).Inc()
+		metrics.TotalQueriesDetails.WithLabelValues(client.Url(), l.Client, l.Reason, l.Status, l.Upstream).Inc()
 	}
 
 	for _, t := range times {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/henrywhitaker3/adguard-exporter/internal/adguard"
@@ -133,7 +134,12 @@ func collectQueryLogStats(ctx context.Context, client *adguard.Client) {
 	}
 
 	for _, l := range queries {
-		metrics.TotalQueriesDetails.WithLabelValues(client.Url(), l.Client, l.Reason, l.Status, l.Upstream).Inc()
+		elapsed, err := strconv.ParseFloat(l.Elapsed, 64)
+		if err != nil {
+			continue
+		}
+		metrics.TotalQueriesDetails.WithLabelValues(client.Url(), l.Client, l.Reason, l.Status, l.Upstream, l.ClientInfo.Name).Set(elapsed)
+		metrics.TotalQueriesDetailsHistogram.WithLabelValues(client.Url(), l.Client, l.Reason, l.Status, l.Upstream, l.ClientInfo.Name).Observe(float64(elapsed))
 	}
 
 	for _, t := range times {

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,31 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:base"
-    ],
-    "postUpdateOptions": [
-        "gomodTidy"
-    ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "renovate::dependencies",
+    "{{#if category}}renovate::{{category}}{{/if}}",
+    "{{#if updateType}}renovate::{{updateType}}{{/if}}",
+    "{{#if datasource}}renovate::{{datasource}}{{/if}}",
+    "{{#if manager}}renovate::{{manager}}{{/if}}",
+    "{{#if vulnerabilitySeverity}}renovate::{{vulnerabilitySeverity}}{{/if}}",
+    "renovate::{{#if isVulnerabilityAlert}}vulnerability{{else}}not-vulnerability{{/if}}"
+  ],
+  "pinDigests": false,
+  "enabled": true,
+  "separateMajorMinor": true,
+  "automerge": true,
+  "packageRules": [
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "postUpdateOptions": [
+        {
+          "gomodTidy": true
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Added `client` label to `query_types` metric as it gives more insight into which client actually queries which domain, plus - how often.

Added `queries_details` gauge having more details (via labels) than current `queries` from stats endpoint.

Added `queries_details_histogram` histogram having more details (via labels) than current `queries` from stats endpoint.

CHANGES summary:

- Modified GetQueryLog to return client-specific query type data
- Added new TotalQueriesDetails metric for detailed query tracking
- Fixed typo in ReplacedParental metric name
- Adjusted QueryTypes metric to include client label
- Enhanced collectQueryLogStats to process and report detailed query data
- Updated README