### PR TITLE
Add BIND_ADDR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $ docker run \
 | `ADGUARD_PASSWORDS` | The password to connect to the adguard api with. Must be in the same order as `ADGUARD_SERVERS` if scraping multiple instances. | `True` | |
 | `INTERVAL` | The interval that the exporter scrapes metrics from the server | `False` | `30s` |
 | `DEBUG` | Turns on the go profiler | `False` | `false` |
+| `BIND_ADDR` | Address to which the Http-Server is bound | `False` | `:9618` |
 
 ## Usage
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Global struct {
 type Server struct {
 	Interval time.Duration `env:"INTERVAL, default=30s"`
 	Debug    bool          `env:"DEBUG, default=false"`
+	BindAddr string        `env:"BIND_ADDR"`
 }
 
 type Config struct {
@@ -41,6 +42,9 @@ func FromEnv() (*Global, error) {
 	serv := &Server{}
 	if err := envconfig.Process(context.Background(), serv); err != nil {
 		return nil, err
+	}
+	if len(serv.BindAddr) == 0 {
+		serv.BindAddr = ":9618"
 	}
 
 	if err := env.Validate(); err != nil {

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -40,9 +40,9 @@ func NewHttp(debug bool) *Http {
 	return http
 }
 
-func (h *Http) Serve() error {
-	log.Println("Starting http server on port 9618")
-	return h.e.Start(":9618")
+func (h *Http) Serve(bindAddr string) error {
+	log.Println("Starting http server on " + bindAddr)
+	return h.e.Start(bindAddr)
 }
 
 func (h *Http) Stop(ctx context.Context) error {

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	http := http.NewHttp(global.Server.Debug)
-	go http.Serve()
+	go http.Serve(global.Server.BindAddr)
 	go worker.Work(ctx, global.Server.Interval, clients)
 	http.Ready(true)
 	http.Healthy(true)


### PR DESCRIPTION
Hi,

I use this exporter on NixOS and hence do not use a docker container, but instead create a systemd service. For that I would like to be able to specify which IP and port the server binds to. I implemented this functionality with a new `BIND_ADDR` environment variable in this PR.
I would be happy if this got merged. Let me know if you want any changes.