### PR TITLE
fix(dhcp): de-duplicate DHCP lease label sets

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -146,20 +146,51 @@ func (d *DhcpLeasesServer) Record(server string, leases []adguard.DhcpLease) {
 	d.leases[server] = leases
 }
 
+// leaseKey is the full label set of an adguard_dhcp_leases series. Used as a
+// dedup map key: a struct of strings is allocation-free and collision-proof
+// (unlike joining the fields into one string).
+type leaseKey struct {
+	server, leaseType, ip, mac, hostname, expires string
+}
+
 func (d *DhcpLeasesServer) Collect(ch chan<- prometheus.Metric) {
+	// AdGuard can hand back duplicate lease rows: an in-place self-update
+	// rebuilds the lease table, and clients behind a MAC-NAT'ing wifi repeater
+	// collapse onto a single bridge MAC. Emitting the same label tuple twice
+	// makes the prometheus registry fail the entire scrape with a hard 500
+	// ("was collected before with the same name and label values"), which
+	// reads as the whole exporter being down. De-duplicate on the full label
+	// set so a duplicate lease is skipped rather than poisoning every metric.
+	//
+	// Build the metric set under d.mu (the worker writes d.leases under the
+	// same lock), then release it before sending to the channel. Holding the
+	// lock across blocking channel sends would stall Record for the whole scrape.
+	d.mu.Lock()
+	seen := make(map[leaseKey]struct{})
+	emit := make([]prometheus.Metric, 0, len(d.leases))
 	for server, leases := range d.leases {
 		for _, lease := range leases {
 			expires := ""
 			if lease.Expires != nil {
 				expires = lease.Expires.Format(time.RFC3339)
 			}
-			ch <- prometheus.MustNewConstMetric(
+			key := leaseKey{server, lease.Type, lease.IP, lease.Mac, lease.Hostname, expires}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			emit = append(emit, prometheus.MustNewConstMetric(
 				d.Desc,
 				prometheus.CounterValue,
 				1,
 				server, lease.Type, lease.IP, lease.Mac, lease.Hostname, expires,
-			)
+			))
 		}
+	}
+	d.mu.Unlock()
+
+	for _, m := range emit {
+		ch <- m
 	}
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/henrywhitaker3/adguard-exporter/internal/adguard"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// AdGuard can return duplicate lease rows (in-place self-update rebuilds the
+// lease table; clients behind a MAC-NAT'ing repeater collapse onto one bridge
+// MAC). Before the dedup fix this poisoned the whole scrape with a hard 500.
+func TestDhcpLeasesCollectDeduplicates(t *testing.T) {
+	server := "http://192.168.3.2"
+	dup := adguard.DhcpLease{
+		Mac:      "2a:fc:97:00:a6:e0",
+		IP:       "192.168.3.114",
+		Hostname: "iphone",
+		Type:     "dynamic",
+	}
+	distinct := adguard.DhcpLease{
+		Mac:      "0a:8b:f4:09:7d:63",
+		IP:       "192.168.3.113",
+		Hostname: "watch",
+		Type:     "dynamic",
+	}
+
+	d := NewDhcpLeasesServer(DhcpLeasesMetric)
+	// Same label tuple appears twice, plus one distinct lease.
+	d.Record(server, []adguard.DhcpLease{dup, dup, distinct})
+
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(d); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	// Gather mirrors what the /metrics handler does. Before the fix this
+	// returned the "was collected before with the same name and label values" error.
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather returned error (duplicate leases not deduped): %v", err)
+	}
+
+	for _, mf := range mfs {
+		if mf.GetName() != "adguard_dhcp_leases" {
+			continue
+		}
+		if got := len(mf.GetMetric()); got != 2 {
+			t.Fatalf("expected 2 deduplicated lease series, got %d", got)
+		}
+		return
+	}
+	t.Fatal("adguard_dhcp_leases metric family not found")
+}


### PR DESCRIPTION
When AdGuard returns duplicate DHCP lease rows, `/metrics` fails with HTTP 500:

```
collected metric "adguard_dhcp_leases" { ... } was collected before with the same name and label values
```

A single duplicate lease takes down the **entire** scrape (every metric, not just leases), so Prometheus reads the exporter as down even though AdGuard itself is healthy. I have seen AdGuard emit duplicate rows after an in-place self-update (lease-table rebuild) and when several clients behind a MAC-NAT'ing wifi repeater share one upstream MAC.

### Fix

De-duplicate on the full label set in `DhcpLeasesServer.Collect` before emitting. The metric set is built under the existing mutex (`Collect` previously read the leases map unlocked while the worker's `Record` writes it, which `go test -race` flags as a data race) and sent to the channel after unlocking so a slow scrape cannot stall `Record`.

Adds a regression test using a pedantic registry; it fails on the current collector and passes with the fix.
